### PR TITLE
Add necessary build command to setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Install JS dependencies and start Pursuance's auto-reloading dev server:
 ```
 cd $(go env GOPATH)/src/github.com/PursuanceProject/pursuance
 npm install
+npm run build
 npm run start
 ```
 


### PR DESCRIPTION
When following the build instructions on a clean machine, running `./pursuance` in the third terminal will result in a go panic since the `build` directory does not exist yet.  To fix this, we run `npm run build` in the first terminal to generate the required files.